### PR TITLE
Update viewport meta tag

### DIFF
--- a/template/source/layouts/layout.erb
+++ b/template/source/layouts/layout.erb
@@ -3,7 +3,8 @@
   <head>
     <meta content="IE=edge" http-equiv="X-UA-Compatible">
     <meta charset="utf-8">
-    <meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" name="viewport">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
     <!-- Use title if it's in the page YAML frontmatter -->
     <title><%= current_page.data.title || "Middleman" %></title>


### PR DESCRIPTION
- Remove `maximum-scale=1.0,user-scalable=no` which presents accessibility issues by preventing users from zooming and scaling.
- Add `shrink-to-fit=no` to tell Safari 9 not to shrink overflowing content to fit the width of the virtual viewport.