### PR TITLE
Specify gem versions

### DIFF
--- a/Thorfile
+++ b/Thorfile
@@ -24,7 +24,7 @@ module Middleman
       end
 
       if @use_livereload
-        insert_into_file 'Gemfile', "gem 'middleman-livereload'\n", after: "# Middleman Gems\n"
+        insert_into_file 'Gemfile', "gem 'middleman-livereload', '~> 3.4'\n", after: "# Middleman Gems\n"
         insert_into_file 'config.rb', <<-eos, after: "# General configuration\n"
 
 # Reload the browser automatically whenever files change
@@ -34,7 +34,7 @@ end
 eos
       end
 
-      insert_into_file 'Gemfile', "gem 'middleman', '>= 4.0.0'\n", after: "# Middleman Gems\n"
+      insert_into_file 'Gemfile', "gem 'middleman', '~> 4.2'\n", after: "# Middleman Gems\n"
     end
 
     def ask_about_rackup


### PR DESCRIPTION
Use pessimistic version constraint so that `bundle install` will give
people the highest-released gem based on minor versions, but will not
jump to a major version.