### PR TITLE
Migrate new projects to use Terser (ES6) instead of Uglifier

### DIFF
--- a/template/Gemfile
+++ b/template/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'middleman', '~> 4.2'
-gem 'middleman-autoprefixer', '~> 2.7'
+gem 'middleman', '~> 4.5'
+gem 'middleman-autoprefixer', '~> 3.0'
+gem 'terser', '~> 1.1'
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby, :x64_mingw]
 gem 'wdm', '~> 0.1', platforms: [:mswin, :mingw, :x64_mingw]

--- a/template/config.rb
+++ b/template/config.rb
@@ -42,5 +42,5 @@ page '/*.txt', layout: false
 
 # configure :build do
 #   activate :minify_css
-#   activate :minify_javascript
+#   activate :minify_javascript, compressor: Terser.new
 # end


### PR DESCRIPTION
More info: 
- https://github.com/middleman/middleman/pull/2651#issuecomment-1894292788
- https://github.com/middleman/middleman/pull/2538

Also:
- Closes #13
- Closes #15

Example project: https://github.com/markets/middleman-bootstrap